### PR TITLE
Remove focal support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - focal
         - jammy
         - noble
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,9 +4,6 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: focal
-    image: ubuntu:20.04
-    privileged: true
   - name: jammy
     image: ubuntu:22.04
     privileged: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,97 +4,99 @@
 #
 #    pip-compile
 #
-ansible==11.1.0
+ansible==13.0.0
     # via -r requirements.in
-ansible-compat==24.10.0
+ansible-compat==25.12.0
     # via
     #   ansible-lint
     #   molecule
-ansible-core==2.18.1
+ansible-core==2.20.0
     # via
     #   ansible
     #   ansible-compat
     #   ansible-lint
     #   molecule
-ansible-lint==25.1.0
+ansible-lint==25.12.0
     # via -r requirements.in
-attrs==25.1.0
+attrs==25.4.0
     # via
     #   jsonschema
     #   referencing
-black==24.10.0
+black==25.12.0
     # via ansible-lint
-bracex==2.5.post1
+bracex==2.6
     # via wcmatch
-certifi==2024.12.14
+certifi==2025.11.12
     # via requests
-cffi==1.17.1
-    # via cryptography
-cfgv==3.4.0
+cffi==2.0.0
+    # via
+    #   ansible-lint
+    #   cryptography
+cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.1
+charset-normalizer==3.4.4
     # via requests
-click==8.1.8
+click==8.3.1
     # via
     #   black
     #   click-help-colors
     #   molecule
 click-help-colors==0.9.4
     # via molecule
-cryptography==44.0.1
-    # via ansible-core
-distlib==0.3.9
+cryptography==46.0.3
+    # via
+    #   ansible-core
+    #   ansible-lint
+distlib==0.4.0
     # via virtualenv
 distro==1.9.0
-    # via selinux
+    # via ansible-lint
 docker==7.1.0
     # via molecule-plugins
 enrich==1.2.7
     # via molecule
-filelock==3.17.0
+filelock==3.20.0
     # via
     #   ansible-lint
     #   virtualenv
-flake8==7.1.1
+flake8==7.3.0
     # via -r requirements.in
-identify==2.6.6
+identify==2.6.15
     # via pre-commit
-idna==3.10
+idna==3.11
     # via requests
-importlib-metadata==8.6.1
-    # via ansible-lint
-iniconfig==2.0.0
+iniconfig==2.3.0
     # via pytest
 jinja2==3.1.6
     # via
     #   ansible-core
     #   molecule
-jsonschema==4.23.0
+jsonschema==4.25.1
     # via
     #   ansible-compat
     #   ansible-lint
     #   molecule
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.9.1
     # via jsonschema
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mccabe==0.7.0
     # via flake8
 mdurl==0.1.2
     # via markdown-it-py
-molecule==25.1.0
+molecule==25.12.0
     # via
     #   -r requirements.in
     #   molecule-plugins
-molecule-plugins[docker]==23.7.0
+molecule-plugins[docker]==25.8.12
     # via -r requirements.in
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.2
+packaging==25.0
     # via
     #   ansible-compat
     #   ansible-core
@@ -107,29 +109,33 @@ pathspec==0.12.1
     #   ansible-lint
     #   black
     #   yamllint
-platformdirs==4.3.6
+platformdirs==4.5.1
     # via
     #   black
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   molecule
     #   pytest
-pre-commit==4.1.0
+pre-commit==4.5.0
     # via -r requirements.in
-pycodestyle==2.12.1
+pycodestyle==2.14.0
     # via flake8
-pycparser==2.22
+pycparser==2.23
     # via cffi
-pyflakes==3.2.0
+pyflakes==3.4.0
     # via flake8
-pygments==2.19.1
-    # via rich
-pytest==8.3.4
+pygments==2.19.2
+    # via
+    #   pytest
+    #   rich
+pytest==9.0.2
     # via pytest-testinfra
-pytest-testinfra==10.1.1
+pytest-testinfra==10.2.2
     # via -r requirements.in
-pyyaml==6.0.2
+pytokens==0.3.0
+    # via black
+pyyaml==6.0.3
     # via
     #   ansible-compat
     #   ansible-core
@@ -137,47 +143,46 @@ pyyaml==6.0.2
     #   molecule
     #   pre-commit
     #   yamllint
-referencing==0.36.2
+referencing==0.37.0
     # via
+    #   ansible-lint
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.32.5
     # via
     #   docker
     #   molecule-plugins
-resolvelib==1.0.1
+resolvelib==1.2.1
     # via ansible-core
-rich==13.9.4
+rich==14.2.0
     # via
     #   enrich
     #   molecule
-rpds-py==0.22.3
+rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.18.10
+ruamel-yaml==0.18.16
     # via ansible-lint
-ruamel-yaml-clib==0.2.12
-    # via ruamel-yaml
-selinux==0.3.0
-    # via molecule-plugins
+ruamel-yaml-clib==0.2.15
+    # via
+    #   ansible-lint
+    #   ruamel-yaml
 subprocess-tee==0.4.2
     # via
     #   ansible-compat
     #   ansible-lint
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via referencing
-urllib3==2.5.0
+urllib3==2.6.1
     # via
     #   docker
     #   requests
-virtualenv==20.29.1
+virtualenv==20.35.4
     # via pre-commit
-wcmatch==10.0
+wcmatch==10.1
     # via
     #   ansible-lint
     #   molecule
-yamllint==1.35.1
+yamllint==1.37.1
     # via ansible-lint
-zipp==3.21.0
-    # via importlib-metadata


### PR DESCRIPTION
The latest Ansible release requires a newer version of Python than Focal shipped with by default. Since Focal is nearing the end of standard support, I'm removing support for Focal in this role.