### PR TITLE
Sync config files to best practices

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,49 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv sync *)",
+      "Bash(uv run ansible-lint *)",
+      "Bash(uv run yamllint *)",
+      "Bash(uv run flake8 *)",
+      "Bash(uv run pre-commit run *)",
+      "Bash(uv run molecule list *)",
+      "Bash(uv run molecule check *)",
+      "Bash(uv run molecule syntax *)",
+      "Bash(uv run molecule create *)",
+      "Bash(uv run molecule converge *)",
+      "Bash(uv run molecule idempotence *)",
+      "Bash(uv run molecule verify *)",
+      "Bash(uv run molecule test *)",
+      "Bash(uv run molecule destroy *)",
+      "Bash(uv run molecule prepare *)",
+      "Bash(uv run molecule side-effect *)",
+      "Bash(uv run molecule cleanup *)",
+      "Bash(uv run pytest *)",
+      "Bash(uv lock *)",
+      "Bash(uv python *)",
+      "Bash(uv pip list *)",
+      "Bash(uv pip show *)",
+      "Bash(uv tree *)",
+      "Bash(uv version *)",
+      "WebFetch(domain:docs.ansible.com)",
+      "WebFetch(domain:ansible.readthedocs.io)",
+      "WebFetch(domain:molecule.readthedocs.io)",
+      "WebFetch(domain:yamllint.readthedocs.io)",
+      "WebFetch(domain:flake8.pycqa.org)",
+      "WebFetch(domain:docs.astral.sh)",
+      "WebFetch(domain:galaxy.ansible.com)",
+      "WebFetch(domain:pre-commit.com)",
+      "WebFetch(domain:testinfra.readthedocs.io)",
+      "WebFetch(domain:docs.docker.com)",
+      "WebFetch(domain:jinja.palletsprojects.com)"
+    ],
+    "ask": [
+      "Bash(uv run ansible *)",
+      "Bash(uv run python *)",
+      "Bash(uv run ansible-galaxy *)",
+      "Bash(uv add *)",
+      "Bash(uv remove *)"
+    ],
+    "deny": []
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
 
   molecule:
     name: Molecule
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
+---
 name: Publish Role to Galaxy
 
-on: # yamllint disable-line rule:truthy
+'on':
   release:
     types: [published]
 
@@ -19,5 +20,8 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: >-
-          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
-          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          ansible-galaxy role import --api-key "$GALAXY_API_KEY"
+          "${GITHUB_REPOSITORY%/*}" "${GITHUB_REPOSITORY#*/}"
+        env:
+          GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ansible/
+.claude/settings.local.json
 .venv/
 *.retry

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ansible/
 .venv/
+*.retry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,4 +33,34 @@ Testing uses Molecule with Docker driver and pytest-testinfra as verifier. The s
 
 ## CI
 
-GitHub Actions runs two jobs on push to master and PRs: lint (ansible-lint, yamllint, flake8) and molecule test. Releases publish to Ansible Galaxy.
+GitHub Actions runs two jobs on push to master and PRs: lint (ansible-lint, yamllint, flake8) and molecule test (runs after lint passes). Releases publish to Ansible Galaxy.
+
+## Development Workflow
+
+Follow this workflow for all code changes.
+
+```
+Code → Document → Verify → Code Review
+  ^                              |
+  └──── fix issues ──────────────┘
+```
+
+### 1. Code
+
+Make the implementation changes. Use FQCNs, name all tasks, and follow the patterns in existing task files.
+
+### 2. Document
+
+Update README.md and CLAUDE.md to reflect any changes to variables, platforms, commands, or architecture. If the ansible plugin is installed, use the `documentator` agent.
+
+### 3. Verify
+
+Run linters (yamllint, ansible-lint, flake8), pre-commit hooks, and molecule tests. All checks must pass before proceeding. If the ansible plugin is installed, use the `verifier` agent.
+
+### 4. Code Review
+
+Review the changes for Ansible best practices, idempotency, security, cross-platform correctness, and test coverage. If the ansible plugin is installed, use the `code-reviewer` agent.
+
+### 5. Iterate
+
+If verification or code review flags issues, fix them and repeat from step 2. Continue until all checks pass and the review is clean.


### PR DESCRIPTION
## Summary

- Add `needs: lint` to CI molecule job so tests run sequentially after lint passes
- Harden release workflow by moving secrets from inline `${{ }}` interpolation to environment variables
- Add YAML document start marker and quote `'on':` in release workflow for consistency with ci.yml
- Add `*.retry` to `.gitignore`
- Add `.claude/settings.json` with standard permissions for uv, linters, molecule, and docs domains
- Add Development Workflow section to `CLAUDE.md`

## Test plan

- [ ] CI lint job passes (yamllint, ansible-lint, flake8)
- [ ] CI molecule job runs after lint passes
- [ ] Release workflow still triggers correctly on GitHub release publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)